### PR TITLE
documentation boilerplate

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -1,0 +1,6 @@
+Rose K. Cersonsky
+Guillaume Fraux
+Sergei Kliavinek
+Alexander Goscinski
+Benjamin A. Helfrect
+Michele Ceriotti

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.http://sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,13 +13,14 @@
 # import os
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
+import sphinx_rtd_theme
 
 
 # -- Project information -----------------------------------------------------
 
 project = "sklearn-COSMO"
-copyright = "2020, Rose K. Cersonsky, Guillaume Fraux, Sergei Kliavinek, Alexander Goscinski, Benjamin Helfrect, and Michele Ceriotti"
-author = "Rose K. Cersonsky, Guillaume Fraux, Sergei Kliavinek, Alexander Goscinski, Benjamin Helfrect, and Michele Ceriotti"
+author = ', '.join(open('../../contributors.txt'))
+copyright = "2020, " + author
 
 # The full version, including alpha/beta/rc tags
 release = "0.1.0"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -22,7 +22,7 @@ copyright = "2020, Rose K. Cersonsky, Guillaume Fraux, Sergei Kliavinek, Alexand
 author = "Rose K. Cersonsky, Guillaume Fraux, Sergei Kliavinek, Alexander Goscinski, Benjamin Helfrect, and Michele Ceriotti"
 
 # The full version, including alpha/beta/rc tags
-release = "0.0.1"
+release = "0.1.0"
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,16 +14,19 @@
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 import sphinx_rtd_theme
-
+import skcosmo
 
 # -- Project information -----------------------------------------------------
 
+# The master toctree document.
+master_doc = 'index'
+
 project = "sklearn-COSMO"
-author = ', '.join(open('../../contributors.txt'))
+author = ", ".join(open("../../contributors.txt"))
 copyright = "2020, " + author
 
 # The full version, including alpha/beta/rc tags
-release = "0.1.0"
+release = str(skcosmo.__version__)
 
 
 # -- General configuration ---------------------------------------------------
@@ -41,15 +44,144 @@ templates_path = ["_templates"]
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = []
 
-
-# -- Options for HTML output -------------------------------------------------
+# -- Options for HTML output ----------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-#
-html_theme = "alabaster"
+html_theme = 'sphinx_rtd_theme'
+
+# Theme options are theme-specific and customize the look and feel of a theme
+# further.  For a list of options available for each theme, see the
+# documentation.
+#html_theme_options = {}
+
+# Add any paths that contain custom themes here, relative to this directory.
+html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+
+# The name for this set of Sphinx documents.  If None, it defaults to
+# "<project> v<release> documentation".
+#html_title = None
+
+# A shorter title for the navigation bar.  Default is the same as html_title.
+#html_short_title = None
+
+# The name of an image file (relative to this directory) to place at the top
+# of the sidebar.
+# html_logo = "images/logo.png"
+
+# The name of an image file (within the static path) to use as favicon of the
+# docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
+# pixels large.
+#html_favicon = None
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ["_static"]
+html_static_path = ['_static']
+
+# Add any extra paths that contain custom files (such as robots.txt or
+# .htaccess) here, relative to this directory. These files are copied
+# directly to the root of the documentation.
+#html_extra_path = []
+
+# If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
+# using the given strftime format.
+#html_last_updated_fmt = '%b %d, %Y'
+
+# If true, SmartyPants will be used to convert quotes and dashes to
+# typographically correct entities.
+#html_use_smartypants = True
+
+# Custom sidebar templates, maps document names to template names.
+#html_sidebars = {}
+
+# Additional templates that should be rendered to pages, maps page names to
+# template names.
+#html_additional_pages = {}
+
+# If false, no module index is generated.
+#html_domain_indices = True
+
+# If false, no index is generated.
+#html_use_index = True
+
+# If true, the index is split into individual pages for each letter.
+#html_split_index = False
+
+# If true, links to the reST sources are added to the pages.
+#html_show_sourcelink = True
+
+# If true, "Created using Sphinx" is shown in the HTML footer. Default is True.
+#html_show_sphinx = True
+
+# If true, "(C) Copyright ..." is shown in the HTML footer. Default is True.
+#html_show_copyright = True
+
+# If true, an OpenSearch description file will be output, and all pages will
+# contain a <link> tag referring to it.  The value of this option must be the
+# base URL from which the finished HTML is served.
+#html_use_opensearch = ''
+
+# This is the file name suffix for HTML files (e.g. ".xhtml").
+#html_file_suffix = None
+
+# Language to be used for generating the HTML full-text search index.
+# Sphinx supports the following languages:
+#   'da', 'de', 'en', 'es', 'fi', 'fr', 'hu', 'it', 'ja'
+#   'nl', 'no', 'pt', 'ro', 'ru', 'sv', 'tr'
+#html_search_language = 'en'
+
+# A dictionary with options for the search language support, empty by default.
+# Now only 'ja' uses this config value
+#html_search_options = {'type': 'default'}
+
+# The name of a javascript file (relative to the configuration directory) that
+# implements a search results scorer. If empty, the default will be used.
+#html_search_scorer = 'scorer.js'
+
+# Output file base name for HTML help builder.
+htmlhelp_basename = 'skcosmodoc'
+
+# -- Options for LaTeX output ---------------------------------------------
+
+latex_elements = {
+# The paper size ('letterpaper' or 'a4paper').
+#'papersize': 'letterpaper',
+
+# The font size ('10pt', '11pt' or '12pt').
+#'pointsize': '10pt',
+
+# Additional stuff for the LaTeX preamble.
+#'preamble': '',
+
+# Latex figure (float) alignment
+#'figure_align': 'htbp',
+}
+
+# Grouping the document tree into LaTeX files. List of tuples
+# (source start file, target name, title,
+#  author, documentclass [howto, manual, or own class]).
+latex_documents = [
+  (master_doc, 'skcosmo.tex', u'sklearn-COSMO Documentation',
+   author, 'manual'),
+]
+
+# The name of an image file (relative to this directory) to place at the top of
+# the title page.
+#latex_logo = None
+
+# For "manual" documents, if this is true, then toplevel headings are parts,
+# not chapters.
+#latex_use_parts = False
+
+# If true, show page references after internal links.
+#latex_show_pagerefs = False
+
+# If true, show URL addresses after external links.
+#latex_show_urls = False
+
+# Documents to append as an appendix to all manuals.
+#latex_appendices = []
+
+# If false, no module index is generated.
+#latex_domain_indices = True

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -19,7 +19,7 @@ import skcosmo
 # -- Project information -----------------------------------------------------
 
 # The master toctree document.
-master_doc = 'index'
+master_doc = "index"
 
 project = "sklearn-COSMO"
 author = ", ".join(open("../../contributors.txt"))
@@ -48,22 +48,22 @@ exclude_patterns = []
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'sphinx_rtd_theme'
+html_theme = "sphinx_rtd_theme"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-#html_theme_options = {}
+# html_theme_options = {}
 
 # Add any paths that contain custom themes here, relative to this directory.
 html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-#html_title = None
+# html_title = None
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
-#html_short_title = None
+# html_short_title = None
 
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.
@@ -72,116 +72,112 @@ html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 # The name of an image file (within the static path) to use as favicon of the
 # docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
 # pixels large.
-#html_favicon = None
+# html_favicon = None
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ["_static"]
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
 # directly to the root of the documentation.
-#html_extra_path = []
+# html_extra_path = []
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.
-#html_last_updated_fmt = '%b %d, %Y'
+# html_last_updated_fmt = '%b %d, %Y'
 
 # If true, SmartyPants will be used to convert quotes and dashes to
 # typographically correct entities.
-#html_use_smartypants = True
+# html_use_smartypants = True
 
 # Custom sidebar templates, maps document names to template names.
-#html_sidebars = {}
+# html_sidebars = {}
 
 # Additional templates that should be rendered to pages, maps page names to
 # template names.
-#html_additional_pages = {}
+# html_additional_pages = {}
 
 # If false, no module index is generated.
-#html_domain_indices = True
+# html_domain_indices = True
 
 # If false, no index is generated.
-#html_use_index = True
+# html_use_index = True
 
 # If true, the index is split into individual pages for each letter.
-#html_split_index = False
+# html_split_index = False
 
 # If true, links to the reST sources are added to the pages.
-#html_show_sourcelink = True
+# html_show_sourcelink = True
 
 # If true, "Created using Sphinx" is shown in the HTML footer. Default is True.
-#html_show_sphinx = True
+# html_show_sphinx = True
 
 # If true, "(C) Copyright ..." is shown in the HTML footer. Default is True.
-#html_show_copyright = True
+# html_show_copyright = True
 
 # If true, an OpenSearch description file will be output, and all pages will
 # contain a <link> tag referring to it.  The value of this option must be the
 # base URL from which the finished HTML is served.
-#html_use_opensearch = ''
+# html_use_opensearch = ''
 
 # This is the file name suffix for HTML files (e.g. ".xhtml").
-#html_file_suffix = None
+# html_file_suffix = None
 
 # Language to be used for generating the HTML full-text search index.
 # Sphinx supports the following languages:
 #   'da', 'de', 'en', 'es', 'fi', 'fr', 'hu', 'it', 'ja'
 #   'nl', 'no', 'pt', 'ro', 'ru', 'sv', 'tr'
-#html_search_language = 'en'
+# html_search_language = 'en'
 
 # A dictionary with options for the search language support, empty by default.
 # Now only 'ja' uses this config value
-#html_search_options = {'type': 'default'}
+# html_search_options = {'type': 'default'}
 
 # The name of a javascript file (relative to the configuration directory) that
 # implements a search results scorer. If empty, the default will be used.
-#html_search_scorer = 'scorer.js'
+# html_search_scorer = 'scorer.js'
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'skcosmodoc'
+htmlhelp_basename = "skcosmodoc"
 
 # -- Options for LaTeX output ---------------------------------------------
 
 latex_elements = {
-# The paper size ('letterpaper' or 'a4paper').
-#'papersize': 'letterpaper',
-
-# The font size ('10pt', '11pt' or '12pt').
-#'pointsize': '10pt',
-
-# Additional stuff for the LaTeX preamble.
-#'preamble': '',
-
-# Latex figure (float) alignment
-#'figure_align': 'htbp',
+    # The paper size ('letterpaper' or 'a4paper').
+    #'papersize': 'letterpaper',
+    # The font size ('10pt', '11pt' or '12pt').
+    #'pointsize': '10pt',
+    # Additional stuff for the LaTeX preamble.
+    #'preamble': '',
+    # Latex figure (float) alignment
+    #'figure_align': 'htbp',
 }
 
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-  (master_doc, 'skcosmo.tex', u'sklearn-COSMO Documentation',
-   author, 'manual'),
+    (master_doc, "skcosmo.tex", u"sklearn-COSMO Documentation", author, "manual"),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
 # the title page.
-#latex_logo = None
+# latex_logo = None
 
 # For "manual" documents, if this is true, then toplevel headings are parts,
 # not chapters.
-#latex_use_parts = False
+# latex_use_parts = False
 
 # If true, show page references after internal links.
-#latex_show_pagerefs = False
+# latex_show_pagerefs = False
 
 # If true, show URL addresses after external links.
-#latex_show_urls = False
+# latex_show_urls = False
 
 # Documents to append as an appendix to all manuals.
-#latex_appendices = []
+# latex_appendices = []
 
 # If false, no module index is generated.
-#latex_domain_indices = True
+# latex_domain_indices = True

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,55 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# http://www.sphinx-doc.org/en/master/config
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('.'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'sklearn-COSMO'
+copyright = '2020, Rose K. Cersonsky, Guillaume Fraux, Sergei Kliavinek, Alexander Goscinski, Benjamin Helfrect, and Michele Ceriotti'
+author = 'Rose K. Cersonsky, Guillaume Fraux, Sergei Kliavinek, Alexander Goscinski, Benjamin Helfrect, and Michele Ceriotti'
+
+# The full version, including alpha/beta/rc tags
+release = '0.0.1'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = []
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'alabaster'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -17,12 +17,12 @@
 
 # -- Project information -----------------------------------------------------
 
-project = 'sklearn-COSMO'
-copyright = '2020, Rose K. Cersonsky, Guillaume Fraux, Sergei Kliavinek, Alexander Goscinski, Benjamin Helfrect, and Michele Ceriotti'
-author = 'Rose K. Cersonsky, Guillaume Fraux, Sergei Kliavinek, Alexander Goscinski, Benjamin Helfrect, and Michele Ceriotti'
+project = "sklearn-COSMO"
+copyright = "2020, Rose K. Cersonsky, Guillaume Fraux, Sergei Kliavinek, Alexander Goscinski, Benjamin Helfrect, and Michele Ceriotti"
+author = "Rose K. Cersonsky, Guillaume Fraux, Sergei Kliavinek, Alexander Goscinski, Benjamin Helfrect, and Michele Ceriotti"
 
 # The full version, including alpha/beta/rc tags
-release = '0.0.1'
+release = "0.0.1"
 
 
 # -- General configuration ---------------------------------------------------
@@ -30,11 +30,10 @@ release = '0.0.1'
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = [
-]
+extensions = []
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -47,9 +46,9 @@ exclude_patterns = []
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'alabaster'
+html_theme = "alabaster"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ["_static"]

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -15,7 +15,7 @@ Indices and tables
 * :ref:`modindex`
 * :ref:`search`
 
-Sklearn-cosmo
+sklearn-COSMO
 #############
 
 A collection of scikit-learn compatible utilities that implement methods

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,76 @@
+
+Welcome to sklearn-COSMO's documentation!
+=========================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`
+# Sklearn-cosmo
+
+[![Test](https://github.com/cosmo-epfl/sklearn-cosmo/workflows/Test/badge.svg)](https://github.com/cosmo-epfl/sklearn-cosmo/actions?query=workflow%3ATest)
+[![codecov](https://codecov.io/gh/cosmo-epfl/sklearn-cosmo/branch/main/graph/badge.svg?token=UZJPJG34SM)](https://codecov.io/gh/cosmo-epfl/sklearn-cosmo/)
+
+A collection of scikit-learn compatible utilities that implement methods
+developed in the COSMO laboratory
+
+:construction: **WARNING**: this package is a work in progress, you can
+currently find the prototype code in the
+[kernel-tutorials](https://github.com/cosmo-epfl/kernel-tutorials) repository.
+
+## Installation
+
+```bash
+pip install https://github.com/cosmo-epfl/sklearn-cosmo
+```
+
+You can then `import skcosmo` in your code!
+
+## Developing the package
+
+Start by installing the development dependencies:
+
+```bash
+pip install tox black flake8
+```
+
+Then this package itself
+
+```bash
+git clone https://github.com/cosmo-epfl/sklearn-cosmo
+cd sklearn-cosmo
+pip install -e .
+```
+
+This install the package in development mode, making is `import`able globally
+and allowing you to edit the code and directly use the updated version.
+
+### Running the tests
+
+```bash
+cd <sklearn-cosmo PATH>
+# run unit tests
+tox
+# run the code formatter
+black --check .
+# run the linter
+flake8
+```
+
+You may want to setup your editor to automatically apply the
+[black](https://black.readthedocs.io/en/stable/) code formatter when saving your
+files, there are plugins to do this with [all major
+editors](https://black.readthedocs.io/en/stable/editor_integration.html).
+
+## License and developers
+
+This project is distributed under the BSD-3-Clauses license. By contributing to
+it you agree to distribute your changes under the same license.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,68 +9,72 @@ Welcome to sklearn-COSMO's documentation!
 
 
 Indices and tables
-==================
+##################
 
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`
-# Sklearn-cosmo
 
-[![Test](https://github.com/cosmo-epfl/sklearn-cosmo/workflows/Test/badge.svg)](https://github.com/cosmo-epfl/sklearn-cosmo/actions?query=workflow%3ATest)
-[![codecov](https://codecov.io/gh/cosmo-epfl/sklearn-cosmo/branch/main/graph/badge.svg?token=UZJPJG34SM)](https://codecov.io/gh/cosmo-epfl/sklearn-cosmo/)
+Sklearn-cosmo
+#############
 
 A collection of scikit-learn compatible utilities that implement methods
-developed in the COSMO laboratory
+developed in the COSMO laboratory.
 
-:construction: **WARNING**: this package is a work in progress, you can
+**WARNING**: this package is a work in progress, you can
 currently find the prototype code in the
 [kernel-tutorials](https://github.com/cosmo-epfl/kernel-tutorials) repository.
 
-## Installation
+Installation
+############
 
-```bash
-pip install https://github.com/cosmo-epfl/sklearn-cosmo
-```
+.. code-block:: bash
+
+  pip install https://github.com/cosmo-epfl/sklearn-cosmo
 
 You can then `import skcosmo` in your code!
 
-## Developing the package
+Developing the package
+######################
 
 Start by installing the development dependencies:
 
-```bash
-pip install tox black flake8
-```
+.. code-block:: bash
+
+  pip install tox black flake8
+
 
 Then this package itself
 
-```bash
-git clone https://github.com/cosmo-epfl/sklearn-cosmo
-cd sklearn-cosmo
-pip install -e .
-```
+.. code-block:: bash
 
-This install the package in development mode, making is `import`able globally
+  git clone https://github.com/cosmo-epfl/sklearn-cosmo
+  cd sklearn-cosmo
+  pip install -e .
+
+This install the package in development mode, making is importable globally
 and allowing you to edit the code and directly use the updated version.
 
-### Running the tests
+Running the tests
+#################
 
-```bash
-cd <sklearn-cosmo PATH>
-# run unit tests
-tox
-# run the code formatter
-black --check .
-# run the linter
-flake8
-```
+.. code-block:: bash
+
+  cd <sklearn-cosmo PATH>
+  # run unit tests
+  tox
+  # run the code formatter
+  black --check .
+  # run the linter
+  flake8
 
 You may want to setup your editor to automatically apply the
 [black](https://black.readthedocs.io/en/stable/) code formatter when saving your
 files, there are plugins to do this with [all major
 editors](https://black.readthedocs.io/en/stable/editor_integration.html).
 
-## License and developers
+License and developers
+######################
 
 This project is distributed under the BSD-3-Clauses license. By contributing to
 it you agree to distribute your changes under the same license.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -23,7 +23,7 @@ developed in the COSMO laboratory.
 
 **WARNING**: this package is a work in progress, you can
 currently find the prototype code in the
-[kernel-tutorials](https://github.com/cosmo-epfl/kernel-tutorials) repository.
+`kernel-tutorials <https://github.com/cosmo-epfl/kernel-tutorials>`_ repository.
 
 Installation
 ############
@@ -32,7 +32,7 @@ Installation
 
   pip install https://github.com/cosmo-epfl/sklearn-cosmo
 
-You can then `import skcosmo` in your code!
+You can then import skcosmo in your code!
 
 Developing the package
 ######################
@@ -52,7 +52,7 @@ Then this package itself
   cd sklearn-cosmo
   pip install -e .
 
-This install the package in development mode, making is importable globally
+This install the package in development mode, making it importable globally
 and allowing you to edit the code and directly use the updated version.
 
 Running the tests
@@ -69,9 +69,9 @@ Running the tests
   flake8
 
 You may want to setup your editor to automatically apply the
-[black](https://black.readthedocs.io/en/stable/) code formatter when saving your
-files, there are plugins to do this with [all major
-editors](https://black.readthedocs.io/en/stable/editor_integration.html).
+`black <https://black.readthedocs.io/en/stable/>`_ code formatter when saving your
+files, there are plugins to do this with `all major
+editors <https://black.readthedocs.io/en/stable/editor_integration.html>`_.
 
 License and developers
 ######################


### PR DESCRIPTION
This PR covers the repository infrastructure to enable RTD documentation, with a boilerplate landing page (literally just the README) to start. Once this is merged, all PR's with new code can include documentation, so it should be considered high priority. All files, other than `index.rst`, were generated by Sphinx.

I've set up readthedocs documentation at:
https://sklearn-cosmo.readthedocs.io/en/latest/
This will pull the documentation from the main branch and build. 

This branch is built at:
https://sklearn-cosmo.readthedocs.io/en/docs-setup_rtd/