### PR TITLE
Revert "Separate sources and configuration for the doc"

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -5,7 +5,7 @@
 # from the environment for the first two.
 SPHINXOPTS    ?=
 SPHINXBUILD   ?= sphinx-build
-SOURCEDIR     = .
+SOURCEDIR     = source
 BUILDDIR      = build
 
 # Put it first so that "make" without argument is like "make help".

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -7,7 +7,7 @@ REM Command file for Sphinx documentation
 if "%SPHINXBUILD%" == "" (
 	set SPHINXBUILD=sphinx-build
 )
-set SOURCEDIR=.
+set SOURCEDIR=source
 set BUILDDIR=build
 
 if "%1" == "" goto help

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -12,9 +12,10 @@
 
 import os
 import sys
+import sphinx_rtd_theme
 
-sys.path.insert(0, os.path.abspath(".."))
-import sphinx_rtd_theme  # noqa
+ROOT = os.path.abspath(os.path.join("..", ".."))
+sys.path.insert(0, ROOT)
 import skcosmo  # noqa
 
 # -- Project information -----------------------------------------------------
@@ -23,7 +24,7 @@ import skcosmo  # noqa
 master_doc = "index"
 
 project = "sklearn-COSMO"
-author = ", ".join(open(os.path.join("..", "..", "contributors.txt")))
+author = ", ".join(open(os.path.join(ROOT, "contributors.txt")))
 copyright = "2020, " + author
 
 # The full version, including alpha/beta/rc tags

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -20,10 +20,10 @@ import skcosmo  # noqa
 # -- Project information -----------------------------------------------------
 
 # The master toctree document.
-master_doc = "source/index"
+master_doc = "index"
 
 project = "sklearn-COSMO"
-author = ", ".join(open(os.path.join(os.path.abspath(".."), "contributors.txt")))
+author = ", ".join(open(os.path.join("..", "..", "contributors.txt")))
 copyright = "2020, " + author
 
 # The full version, including alpha/beta/rc tags


### PR DESCRIPTION
This reverts commit af766baff01fc19f95e7aa0d5856c84f237ea739.

RTD does not support this configuration: https://github.com/readthedocs/readthedocs.org/issues/1543