### PR TITLE
Set the setuptools package version without importing skcosmo

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,6 @@
 requires = [
     "setuptools",
     "wheel",
-    "attr",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
 [metadata]
 name = skcosmo
-version = attr: skcosmo.__version__
 long_description = file: README.md
 long_description_content_type = text/markdown
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python3
-# this is a shim file to allow `python setup.py develop`/`pip install -e` to
-# work
 from setuptools import setup
+import re
+
+__version__ = re.search(
+    r'__version__\s*=\s*[\'"]([^\'"]*)[\'"]', open("skcosmo/__init__.py").read()
+).group(1)
 
 if __name__ == "__main__":
-    setup()
+    setup(version=__version__)


### PR DESCRIPTION
Trying to import skcosmo (through `version: attr: skcosmo.__version__` in setup.cfg) would fail if some package are missing **when creating the sdist**, so instead I read the file and check for the `__version__ = "X.Y.Z"` line.

[This fixes](https://github.com/Luthaf/sklearn-cosmo/runs/1417474934) the issue @agoscinski was seeing in #9.