### PR TITLE
Ensure dataset are packaged with the code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.pyc
+__pycache__
 *.egg-info
 
 .tox/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+recursive-include skcosmo/datasets/data/ *
+recursive-include skcosmo/datasets/descr/ *

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,11 +10,12 @@ legacy_tox_ini = """
 [tox]
 
 [testenv]
+changedir = tests
 deps =
     coverage[toml]
 
 commands =
-    coverage run -m unittest discover -p "*.py" -s tests
+    coverage run -m unittest discover -p "*.py"
     coverage xml
 """
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,9 +12,10 @@ license_files = LICENSE
 ; classifiers =
 
 [options]
+include_package_data = True
 zip_safe = True
 packages = find:
-install_requires = 
+install_requires =
     numpy
     sklearn
 

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,2 @@
+.coverage
+coverage.xml


### PR DESCRIPTION
Follow up to #9. 

The tests were passing before because tox was running in the root, finding the `/skcosmo` version of the code before the version in `/.tox/python/lib/python3.X/site-packages/skcosmo` (which is the one installed through setup.py, and the one that users will have installed). I changed the tox script to account for this.